### PR TITLE
Fix: adaptive_retry_wait not triggered on ServiceError in create_instance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -266,6 +266,7 @@ class OciOccFix:
             logging.warning(
                 f"Create failed in {availability_domain}: {e.code} - {e.message}"
             )
+            self.adaptive_retry_wait(e.code)
             return None
         except Exception as e:
             logging.error(f"Unexpected creation error: {str(e)}")


### PR DESCRIPTION
Describe the bug:
The `adaptive_retry_wait` method was never called when `create_instance` encountered a `TooManyRequests` or other `ServiceError`. This is because `create_instance` catches `oci.exceptions.ServiceError` internally and returns `None`, so the error never reaches the outer exception handler in `run()` where `adaptive_retry_wait` was being called. As a result, the retry interval stayed fixed at `initial_retry_interval` regardless of OCI rate limiting, causing the bot to spam the API without backoff.

Changes made:
- Backoff on ServiceError: Added a call to `self.adaptive_retry_wait(e.code)` inside the `ServiceError` handler in `create_instance`.  
- Behavior:
  - `TooManyRequests` triggers exponential backoff.  
  - `InternalError` (out of capacity) responses reduce the wait toward `min_interval`. 