### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this project is
+Single-product Python worker: **OCI-OcC-Fix** (`bot.py`). It repeatedly calls the
+Oracle Cloud (OCI) API to launch a compute instance, retrying with adaptive backoff
+until Oracle has capacity. There is **no web server, no listening ports, and no local
+database/queue/cache** — do not try to provision any. Optional Telegram notifications
+self-disable when their config is left as `xxxx`.
+
+### Setup / run / test
+- Dependencies: `pip install -r requirements.txt` (handled by the startup update script).
+- Run the bot: `python3 bot.py` (see `README.md` for `--config` / `--oci-config` flags).
+- Config wizard: `python3 setup_wizard.py` (interactive; `--gui` needs tkinter).
+- There is **no test suite and no configured linter** (the `.github/workflows` only do
+  auto-release + traffic badges). Lightweight sanity check: `python3 -m py_compile bot.py setup_wizard.py`.
+
+### Non-obvious gotchas
+- `bot.py` needs both `configuration.ini` (app settings) and `config` (OCI SDK
+  credentials file, standard OCI format) in the working directory, plus the PEM private
+  key referenced by `key_file`. The committed `configuration.ini` and `config` are
+  **placeholder templates** — never commit real secrets into them.
+- Real end-to-end capacity-launch behavior requires a genuine OCI tenancy + API key
+  (secrets not in the repo). Without valid credentials the bot still runs the full
+  pipeline (config load → OCI client init → live OCI API call) and then exits with
+  `401 NotAuthenticated` at resource validation. That 401 is the expected proof the
+  environment is wired correctly, not an environment bug.
+- To exercise the bot without touching the committed templates, generate config in a
+  temp dir and pass `--config` / `--oci-config`. `setup_wizard.py` can be driven
+  non-interactively by piping newline-separated answers to stdin.
+- `bot.py`'s normal (authenticated) run loops forever until an instance is launched;
+  when testing, wrap it with `timeout`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and documents the development environment for **OCI-OcC-Fix**, a single Python worker bot that retries Oracle Cloud (OCI) instance launches until capacity is available.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the product, how to run/test, and non-obvious gotchas (no web server/DB/ports, no test suite/linter, placeholder config templates, expected `401 NotAuthenticated` without real OCI creds).
- Registers the startup update script: `pip install -r requirements.txt`.

No application code was modified.

## Environment verification
- Installed dependencies from `requirements.txt` (`oci`, `pyTelegramBotAPI`, `requests`, `python-dotenv`, `configparser`).
- Generated a valid OCI SDK config + RSA key via `setup_wizard.py` (run non-interactively) and ran `bot.py` against it end-to-end. The bot loaded config, initialized all four OCI SDK clients, and made a live call to the Oracle Cloud API (`https://iaas.us-ashburn-1.oraclecloud.com/...`), returning `401 NotAuthenticated` — the expected result with placeholder credentials, confirming the pipeline runs end-to-end.

Real capacity-launch behavior requires a genuine OCI tenancy + API key (secrets not present in the repo).

## Testing
- ✅ `pip install -r requirements.txt`
- ✅ `python3 -m py_compile bot.py setup_wizard.py`
- ✅ `python3 bot.py --help` / `python3 setup_wizard.py --help`
- ✅ `python3 setup_wizard.py` (non-interactive, generated valid config)
- ✅ `python3 bot.py --config ... --oci-config ...` (reached OCI API, expected 401 with placeholder creds)

[bot_run_demo.log](https://cursor.com/agents/bc-a354a35f-c106-42ed-85f9-894c0ab718da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbot_run_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a354a35f-c106-42ed-85f9-894c0ab718da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a354a35f-c106-42ed-85f9-894c0ab718da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

